### PR TITLE
init: new jwt guard & add access_token to get front display API

### DIFF
--- a/src/services/event-svc/modules/event/queries/getEventFrontDisplay/getEventFrontDisplay.controller.ts
+++ b/src/services/event-svc/modules/event/queries/getEventFrontDisplay/getEventFrontDisplay.controller.ts
@@ -1,14 +1,21 @@
-import { Controller, Get, Query, Res, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Request, Res, HttpStatus, UseGuards } from '@nestjs/common';
 import { GetEventFrontDisplayService } from './getEventFrontDisplay.service';
+import { JwtOptionalGuard } from 'src/shared/guard/jwt-optional.guard';
 import { Response } from 'express';
-import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { GetEventFrontDisplayResponse } from './getEventFrontDisplay-response.dto';
+import { SlackService } from 'src/infrastructure/adapters/slack/slack.service';
 
 @ApiTags('Event Service - Event')
 @Controller('api/event')
 export class GetEventFrontDisplayController {
-  constructor(private readonly frontDisplayService: GetEventFrontDisplayService) {}
+  constructor(
+    private readonly frontDisplayService: GetEventFrontDisplayService,
+    private readonly slackService: SlackService
+  ) { }
 
+  @ApiBearerAuth('access-token')
+  @UseGuards(JwtOptionalGuard)
   @Get('/front-display')
   @ApiOperation({ summary: 'Get front display data' })
   @ApiResponse({
@@ -20,23 +27,32 @@ export class GetEventFrontDisplayController {
     status: HttpStatus.BAD_REQUEST,
     description: 'Fetch front display data failed',
   })
-  async getFrontDisplay(@Res() res: Response) {
-    const result = await this.frontDisplayService.execute();
+  async getFrontDisplay(@Res() res: Response, @Request() req) {
+    try {
+      const result = await this.frontDisplayService.execute();
 
-    if (result.isErr()) {
-      return res
-        .status(HttpStatus.BAD_REQUEST)
-        .json({
-          statusCode: HttpStatus.BAD_REQUEST,
-          message: result.unwrapErr().message,
-        });
+      if (result.isErr()) {
+        return res
+          .status(HttpStatus.BAD_REQUEST)
+          .json({
+            statusCode: HttpStatus.BAD_REQUEST,
+            message: result.unwrapErr().message,
+          });
+      }
+
+      const data = result.unwrap();
+      return res.status(HttpStatus.OK).json({
+        statusCode: HttpStatus.OK,
+        message: 'Front display data retrieved successfully',
+        data,
+      });
+    } catch (error) {
+      this.slackService.sendError(`Event Service - Event front display >>> GetEventFrontDisplayController: ${error.message}`);
+
+      return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        message: 'Internal server error',
+      });
     }
-
-    const data = result.unwrap();
-    return res.status(HttpStatus.OK).json({
-      statusCode: HttpStatus.OK,
-      message: 'Front display data retrieved successfully',
-      data,
-    });
   }
 }

--- a/src/shared/guard/jwt-optional.guard.ts
+++ b/src/shared/guard/jwt-optional.guard.ts
@@ -1,0 +1,15 @@
+// src/shared/guards/jwt-optional.guard.ts
+
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtOptionalGuard extends AuthGuard('jwt') {
+  handleRequest(err, user, info) {
+    // no err & no user (no token) => {}
+    if (err || !user) {
+      return {}; // Trả về đối tượng trống nếu không có token
+    }
+    return user;
+  }
+}

--- a/src/shared/strategies/jwt.strategy.ts
+++ b/src/shared/strategies/jwt.strategy.ts
@@ -24,8 +24,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(req: Request, payload: any) {
     const authHeader = req.headers.authorization;
     if (!authHeader) {
-      throw new UnauthorizedException('Authorization header missing');
+      // throw new UnauthorizedException('Authorization header missing');
+      return {};
     }
+
     const [type, token] = authHeader.split(' ');
     if (type !== 'Bearer' || !token) {
       throw new UnauthorizedException('Invalid authorization header format');


### PR DESCRIPTION
- Tui sửa lại file jwt.strategy.ts ở 1 chỗ là
![image](https://github.com/user-attachments/assets/14a26055-2a59-4777-b228-a9ca83459f79)
Nghĩa là nếu kh có token thì sẽ kh gây ra lỗi ở đây, chỉ trả về 1 object rỗng thui
- File jwt-optional.guard.ts: nếu kh có token hay kh có lỗi, sẽ trả về 1 object rỗng chứ kh ném lỗi 401
- Tui có thêm cái jwt mới này vào controller của front display rùi ông xem qua thử nhen